### PR TITLE
ensure license is added to distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 from icnsutil import __doc__, __version__
 
-with open('README.md') as fp:
+with open('README.md', encoding='utf-8') as fp:
     longdesc = fp.read()
 
 setup(
@@ -52,4 +52,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities',
     ],
+    include_package_data=True
 )


### PR DESCRIPTION
Thanks for this tool!

This PR ensures the `LICENSE` file makes it into the distribution. While not _strictly_ required by the MIT license, this is nonetheless useful for downstreams that require such data.

Motivation: looking to package this for [`conda-forge`](https://conda-forge.org/).